### PR TITLE
Declare struct outside union

### DIFF
--- a/include/tscioctl.h
+++ b/include/tscioctl.h
@@ -294,6 +294,9 @@ struct tsc_ioctl_map_win
 #define RDWR_SWAP_DATA         0x80
 #define RDWR_LOOP        0x80000000
 
+
+struct rdwr_mode {char ads; char space; char swap; char am;}
+
 struct tsc_ioctl_rdwr
 {
   uint64_t rem_addr;
@@ -302,7 +305,7 @@ struct tsc_ioctl_rdwr
   union
   {
     uint mode;
-    struct rdwr_mode {char ads; char space; char swap; char am;}m;
+    struct rdwr_mode m;
   }; 
 };
 

--- a/include/tscioctl.h
+++ b/include/tscioctl.h
@@ -295,7 +295,7 @@ struct tsc_ioctl_map_win
 #define RDWR_LOOP        0x80000000
 
 
-struct rdwr_mode {char ads; char space; char swap; char am;}
+struct rdwr_mode {char ads; char space; char swap; char am;};
 
 struct tsc_ioctl_rdwr
 {


### PR DESCRIPTION
When including the lib inside a C++ program, the compilation fails with the following error:
`error: 'struct tsc_ioctl_rdwr::<unnamed union>::rdwr_mode' invalid; an anonymous union may only have public non-static data members [-fpermissive]`

The modification I'm proposing fix this error and seems to be harmless.