### PR TITLE
Remove -fstack-protector-strong from Makefile CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ TSCTST_OBJS :=$(addsuffix .o,$(basename $(TSCTST_SRCS)))
 TSBLIB:= libtsc.so
 ADCLIB:= libadc.so
 
-CFLAGS := -Wall -fstack-protector-strong
+CFLAGS := -Wall
 LDFLAGS :=-Wall -lrt -lm
 
 BINS := TscMon SmemCalibration 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -32,7 +32,7 @@ CFLAGS	        := -MP -MMD -Wall $(INCDIRS) $(EXTRAFLAGS)
 SRCS_LIB_TSC	:= tsculib.c clilib.c tscextlib.c tstlib.c ponmboxlib.c \
                    mtca4amclib.c mtca4rtmlib.c pca9539lib.c i2ceepromlib.c \
                    fbi1482lib.c rcf1450lib.c rsp1461lib.c rdt1465lib.c \
-                   rdt1465lib.c rcc1466lib.c
+                   rcc1466lib.c
 SRCS_LIB_ADC	:= adclib.c  adc3112lib.c fscope3112lib.c adc3110lib.c \
                    gscopelib.c gscope3110lib.c adc3117lib.c adc3210lib.c 
 


### PR DESCRIPTION
Fixes [ICSHWI-4845]

When compiling TscMon with the -fstack-protector-* compiler flag enabled, we are seeing odd behaviour with the 'pr' command.
This can be worked-around by removing the flag from the Makefile.