### PR TITLE
Always include stdint.h when compiling with GNU_SOURCE defined

### DIFF
--- a/include/tscioctl.h
+++ b/include/tscioctl.h
@@ -51,9 +51,13 @@
 
 #include "tsc.h"
 
+#ifndef _GNU_SOURCE
 #ifndef _LINUX_TYPES_H
 #include <stdint.h>
 #endif /* _LINUX_TYPES_H */
+#else
+#include <stdint.h>
+#endif /*_GNU_SOURCE */
 
 #define TSC_BOARD_IFC1211        0x73571211
 #define TSC_BOARD_IFC1410        0x73571410


### PR DESCRIPTION
Prevents compilation errors when using gcc > 8.3.0 and the GNU_SOURCE macro

[ICSHWI-5585]